### PR TITLE
[fix]还原之前wzt把更新服务注释了的问题

### DIFF
--- a/lib_common/build.gradle
+++ b/lib_common/build.gradle
@@ -106,6 +106,7 @@ dependencies {
     //bugly
     api deps.bugly.crashreport
     api deps.bugly.nativecrashreport
+    api deps.bugly.crashreport_upgrade
 
     // walle
     api deps.walle.runtime

--- a/lib_common/src/main/AndroidManifest.xml
+++ b/lib_common/src/main/AndroidManifest.xml
@@ -42,11 +42,6 @@
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
 
     <application>
-<!--        <service-->
-<!--            android:name="com.mredrock.cyxbs.update.component.AppUpdateDownloadService"-->
-<!--            android:enabled="true"-->
-<!--            android:exported="true" />-->
-
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileProvider"
@@ -56,10 +51,10 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/provider_paths" />
         </provider> <!-- bugly -->
-<!--        <activity-->
-<!--            android:name="com.tencent.bugly.beta.ui.BetaActivity"-->
-<!--            android:configChanges="keyboardHidden|orientation|screenSize|locale"-->
-<!--            android:theme="@android:style/Theme.Translucent" />-->
+        <activity
+            android:name="com.tencent.bugly.beta.ui.BetaActivity"
+            android:configChanges="keyboardHidden|orientation|screenSize|locale"
+            android:theme="@android:style/Theme.Translucent" />
         <activity
             android:name=".ui.ExceptionActivity"
             android:process=":exception_handler"

--- a/lib_update/src/main/AndroidManifest.xml
+++ b/lib_update/src/main/AndroidManifest.xml
@@ -1,1 +1,9 @@
-<manifest package="com.mredrock.cyxbs.update" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.mredrock.cyxbs.update">
+    <application>
+        <service
+            android:name="com.mredrock.cyxbs.update.component.AppUpdateDownloadService"
+            android:enabled="true"
+            android:exported="false" />
+    </application>
+</manifest>


### PR DESCRIPTION
因为更新服务是在common模块中的AndroidManifest中注册的，而common模块没有导入update模块，导致在common中注册的那个服务找不到，然后wzt以为没有用到，就把它给注释了