### PR TITLE
:sparkles: 1、网络请求更优雅的异常处理；2、新增 ArgumentHelper

### DIFF
--- a/lib_base/src/main/java/com/mredrock/cyxbs/lib/base/operations/OperationUi.kt
+++ b/lib_base/src/main/java/com/mredrock/cyxbs/lib/base/operations/OperationUi.kt
@@ -3,8 +3,8 @@ package com.mredrock.cyxbs.lib.base.operations
 import android.view.View
 import androidx.lifecycle.LifecycleOwner
 import com.mredrock.cyxbs.api.account.IAccountService
-import com.mredrock.cyxbs.lib.utils.extensions.RxjavaLifecycle
-import com.mredrock.cyxbs.lib.utils.extensions.ToastUtils
+import com.mredrock.cyxbs.lib.base.utils.RxjavaLifecycle
+import com.mredrock.cyxbs.lib.base.utils.ToastUtils
 import com.mredrock.cyxbs.lib.utils.service.impl
 
 /**

--- a/lib_base/src/main/java/com/mredrock/cyxbs/lib/base/ui/BaseActivity.kt
+++ b/lib_base/src/main/java/com/mredrock/cyxbs/lib/base/ui/BaseActivity.kt
@@ -1,6 +1,7 @@
 package com.mredrock.cyxbs.lib.base.ui
 
 import android.annotation.SuppressLint
+import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.graphics.Color
 import android.os.Bundle
@@ -13,6 +14,7 @@ import androidx.fragment.app.FragmentTransaction
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import com.mredrock.cyxbs.lib.base.operations.OperationActivity
+import com.mredrock.cyxbs.lib.base.utils.IntentHelper
 
 /**
  * 绝对基础的抽象
@@ -113,4 +115,16 @@ abstract class BaseActivity : OperationActivity() {
     get() = window.decorView
   
   final override fun getViewLifecycleOwner(): LifecycleOwner = this
+  
+  
+  
+  /**
+   * 快速得到 intent 中的变量，直接使用反射拿了变量的名字。支持声明为 var 修改对应参数
+   * ```
+   * var key by intent.helper<String>()
+   *
+   * 这样写会在 intent 中寻找名字叫 key 的参数
+   * ```
+   */
+  fun <T : Any> Intent.helper() = IntentHelper<T> { intent }
 }

--- a/lib_base/src/main/java/com/mredrock/cyxbs/lib/base/ui/BaseFragment.kt
+++ b/lib_base/src/main/java/com/mredrock/cyxbs/lib/base/ui/BaseFragment.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleCoroutineScope
 import androidx.lifecycle.coroutineScope
 import com.mredrock.cyxbs.lib.base.operations.OperationFragment
+import com.mredrock.cyxbs.lib.base.utils.ArgumentHelper
 
 /**
  * 绝对基础的抽象
@@ -115,4 +116,28 @@ abstract class BaseFragment : OperationFragment {
   
   val viewLifecycleScope: LifecycleCoroutineScope
     get() = viewLifecycleOwner.lifecycle.coroutineScope
+  
+  
+  
+  /**
+   * 快速得到 arguments 中的变量，直接使用反射拿了变量的名字。支持声明为 var 修改对应参数
+   * ```
+   * companion object {
+   *   fun newInstance(
+   *     key: String
+   *   ) : Fragment {
+   *     return Fragment().apply {
+   *       arguments = bundleOf(
+   *         this::key.name to key // 这里直接拿变量名字
+   *       )
+   *     }
+   *   }
+   * }
+   *
+   * var key by arguments.helper<String>()
+   *
+   * 这样写会在 arguments 中寻找名字叫 key 的参数
+   * ```
+   */
+  fun <T : Any> Bundle?.helper() = ArgumentHelper<T>{ this!! }
 }

--- a/lib_base/src/main/java/com/mredrock/cyxbs/lib/base/ui/BaseUi.kt
+++ b/lib_base/src/main/java/com/mredrock/cyxbs/lib/base/ui/BaseUi.kt
@@ -98,6 +98,7 @@ interface BaseUi : OperationUi {
   }
   
   // Rxjava 自动关流
+  @Deprecated("内部方法，禁止调用", level = DeprecationLevel.HIDDEN)
   override fun onAddRxjava(disposable: Disposable) {
     getViewLifecycleOwner().lifecycle.addObserver(
       object : LifecycleEventObserver {

--- a/lib_base/src/main/java/com/mredrock/cyxbs/lib/base/ui/BaseViewModel.kt
+++ b/lib_base/src/main/java/com/mredrock/cyxbs/lib/base/ui/BaseViewModel.kt
@@ -4,8 +4,8 @@ import android.content.Context
 import androidx.annotation.CallSuper
 import androidx.lifecycle.*
 import com.mredrock.cyxbs.lib.base.BaseApp
-import com.mredrock.cyxbs.lib.utils.extensions.RxjavaLifecycle
-import com.mredrock.cyxbs.lib.utils.extensions.ToastUtils
+import com.mredrock.cyxbs.lib.base.utils.RxjavaLifecycle
+import com.mredrock.cyxbs.lib.base.utils.ToastUtils
 import io.reactivex.rxjava3.disposables.Disposable
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch

--- a/lib_base/src/main/java/com/mredrock/cyxbs/lib/base/utils/ArgumentHelper.kt
+++ b/lib_base/src/main/java/com/mredrock/cyxbs/lib/base/utils/ArgumentHelper.kt
@@ -1,0 +1,95 @@
+package com.mredrock.cyxbs.lib.base.utils
+
+import android.os.Bundle
+import android.os.IBinder
+import android.os.Parcelable
+import android.util.Size
+import android.util.SizeF
+import androidx.core.os.bundleOf
+import java.io.Serializable
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
+
+/**
+ * 这里面所有的类型参考了官方的设计：[bundleOf]
+ */
+class ArgumentHelper<T: Any>(
+  private val arguments: () -> Bundle
+) : ReadWriteProperty<Any, T> {
+    
+    private var mValue: T? = null
+    
+    @Suppress("UNCHECKED_CAST")
+    override fun getValue(thisRef: Any, property: KProperty<*>): T {
+      if (mValue != null) return mValue!!
+      mValue = arguments.invoke().get(property.name) as T
+      return mValue!!
+    }
+    
+    override fun setValue(thisRef: Any, property: KProperty<*>, value: T) {
+      val name = property.name
+      arguments.invoke().apply {
+        when (value) {
+          is String -> putString(name, value) // 优先判断 String
+          
+          // Scalars
+          is Int -> putInt(name, value)
+          is Boolean -> putBoolean(name, value)
+          is Byte -> putByte(name, value)
+          is Char -> putChar(name, value)
+          is Double -> putDouble(name, value)
+          is Float -> putFloat(name, value)
+          is Long -> putLong(name, value)
+          is Short -> putShort(name, value)
+  
+          // References
+          is Bundle -> putBundle(name, value)
+          is CharSequence -> putCharSequence(name, value)
+          is Parcelable -> putParcelable(name, value)
+  
+          // Scalar arrays
+          is BooleanArray -> putBooleanArray(name, value)
+          is ByteArray -> putByteArray(name, value)
+          is CharArray -> putCharArray(name, value)
+          is DoubleArray -> putDoubleArray(name, value)
+          is FloatArray -> putFloatArray(name, value)
+          is IntArray -> putIntArray(name, value)
+          is LongArray -> putLongArray(name, value)
+          is ShortArray -> putShortArray(name, value)
+  
+          // Reference arrays
+          is Array<*> -> {
+            val componentType = value::class.java.componentType!!
+            @Suppress("UNCHECKED_CAST") // Checked by reflection.
+            when {
+              Parcelable::class.java.isAssignableFrom(componentType) -> {
+                putParcelableArray(name, value as Array<Parcelable>)
+              }
+              String::class.java.isAssignableFrom(componentType) -> {
+                putStringArray(name, value as Array<String>)
+              }
+              CharSequence::class.java.isAssignableFrom(componentType) -> {
+                putCharSequenceArray(name, value as Array<CharSequence>)
+              }
+              Serializable::class.java.isAssignableFrom(componentType) -> {
+                putSerializable(name, value)
+              }
+              else -> {
+                val valueType = componentType.canonicalName
+                throw IllegalArgumentException(
+                  "非法数组类型 $valueType for key \"$name\""
+                )
+              }
+            }
+          }
+          // Last resort. Also we must check this after Array<*> as all arrays are serializable.
+          is Serializable -> putSerializable(name, value)
+          is IBinder -> putBinder(name, value)
+          is Size -> putSize(name, value)
+          is SizeF -> putSizeF(name, value)
+          else -> error("未实现该类型 ${value::class.java.name} for key \"$name\"")
+        }
+      }
+      mValue = value
+    }
+  }

--- a/lib_base/src/main/java/com/mredrock/cyxbs/lib/base/utils/IntentHelper.kt
+++ b/lib_base/src/main/java/com/mredrock/cyxbs/lib/base/utils/IntentHelper.kt
@@ -1,0 +1,150 @@
+package com.mredrock.cyxbs.lib.base.utils
+
+import android.content.Intent
+import android.os.Bundle
+import android.os.Parcelable
+import androidx.core.os.bundleOf
+import com.mredrock.cyxbs.lib.utils.utils.GenericityUtils
+import java.io.Serializable
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
+
+/**
+ * 这里面所有的类型参考了官方的设计：[bundleOf]
+ */
+class IntentHelper<T: Any>(
+  val intent: () -> Intent
+) : ReadWriteProperty<Any, T> {
+    
+    private var mValue: T? = null
+    private val mType = GenericityUtils.getGenericClassFromSuperClass<T, Any>(javaClass)
+    
+    @Suppress("UNCHECKED_CAST")
+    override fun getValue(thisRef: Any, property: KProperty<*>): T {
+      if (mValue != null) return mValue!!
+      val name = property.name
+      mValue = intent.invoke().run {
+        // 因为 intent 的 getExtra() 方法被废弃，所以只能一个一个判断
+        when (mType) {
+          String::class -> getStringExtra(name)
+  
+          Int::class -> getIntExtra(name, Int.MIN_VALUE)
+          Boolean::class -> getBooleanExtra(name, false)
+          Byte::class -> getByteExtra(name, Byte.MIN_VALUE)
+          Char::class -> getCharExtra(name, ' ')
+          Double::class -> getDoubleExtra(name, Double.MIN_VALUE)
+          Float::class -> getFloatExtra(name, Float.MIN_VALUE)
+          Long::class -> getLongExtra(name, Long.MIN_VALUE)
+          Short::class -> getShortExtra(name, Short.MIN_VALUE)
+          
+          Bundle::class -> getBundleExtra(name)
+          BooleanArray::class -> getBooleanArrayExtra(name)
+          ByteArray::class -> getByteArrayExtra(name)
+          CharArray::class -> getCharArrayExtra(name)
+          DoubleArray::class -> getDoubleArrayExtra(name)
+          FloatArray::class -> getFloatArrayExtra(name)
+          IntArray::class -> getIntArrayExtra(name)
+          LongArray::class -> getLongArrayExtra(name)
+          ShortArray::class -> getShortArrayExtra(name)
+          
+          Array::class -> {
+            val componentType = mType::class.java.componentType!!
+            when {
+              Parcelable::class.java.isAssignableFrom(componentType) -> {
+                getParcelableArrayExtra(name)
+              }
+              String::class.java.isAssignableFrom(componentType) -> {
+                getStringArrayExtra(name)
+              }
+              CharSequence::class.java.isAssignableFrom(componentType) -> {
+                getCharSequenceArrayExtra(name)
+              }
+              Serializable::class.java.isAssignableFrom(componentType) -> {
+                getSerializableExtra(name)
+              }
+              else -> {
+                val valueType = componentType.canonicalName
+                throw IllegalArgumentException(
+                  "非法数组类型 $valueType for key \"$name\""
+                )
+              }
+            }
+          }
+          
+          else -> {
+            when {
+              CharSequence::class.java.isAssignableFrom(mType) -> getCharExtra(name, ' ')
+              Parcelable::class.java.isAssignableFrom(mType) -> getParcelableExtra(name)
+              Serializable::class.java.isAssignableFrom(mType) -> getSerializableExtra(name)
+              else -> error("未实现该类型 ${mType::class.java.name} for key \"$name\"")
+            }
+          }
+        }
+      } as T
+      return mValue!!
+    }
+    
+    override fun setValue(thisRef: Any, property: KProperty<*>, value: T) {
+      val name = property.name
+      intent.invoke().apply {
+        when (value) {
+          is String -> putExtra(name, value) // 优先判断 String
+          
+          // Scalars
+          is Int -> putExtra(name, value)
+          is Boolean -> putExtra(name, value)
+          is Byte -> putExtra(name, value)
+          is Char -> putExtra(name, value)
+          is Double -> putExtra(name, value)
+          is Float -> putExtra(name, value)
+          is Long -> putExtra(name, value)
+          is Short -> putExtra(name, value)
+    
+          // References
+          is Bundle -> putExtra(name, value)
+          is CharSequence -> putExtra(name, value)
+          is Parcelable -> putExtra(name, value)
+    
+          // Scalar arrays
+          is BooleanArray -> putExtra(name, value)
+          is ByteArray -> putExtra(name, value)
+          is CharArray -> putExtra(name, value)
+          is DoubleArray -> putExtra(name, value)
+          is FloatArray -> putExtra(name, value)
+          is IntArray -> putExtra(name, value)
+          is LongArray -> putExtra(name, value)
+          is ShortArray -> putExtra(name, value)
+    
+          // Reference arrays
+          is Array<*> -> {
+            val componentType = value::class.java.componentType!!
+            @Suppress("UNCHECKED_CAST") // Checked by reflection.
+            when {
+              Parcelable::class.java.isAssignableFrom(componentType) -> {
+                putExtra(name, value as Array<Parcelable>)
+              }
+              String::class.java.isAssignableFrom(componentType) -> {
+                putExtra(name, value as Array<String>)
+              }
+              CharSequence::class.java.isAssignableFrom(componentType) -> {
+                putExtra(name, value as Array<CharSequence>)
+              }
+              Serializable::class.java.isAssignableFrom(componentType) -> {
+                putExtra(name, value)
+              }
+              else -> {
+                val valueType = componentType.canonicalName
+                throw IllegalArgumentException(
+                  "非法数组类型 $valueType for key \"$name\""
+                )
+              }
+            }
+          }
+          // Last resort. Also we must check this after Array<*> as all arrays are serializable.
+          is Serializable -> putExtra(name, value)
+          else -> error("未实现该类型 ${value::class.java.name} for key \"$name\"")
+        }
+      }
+      mValue = value
+    }
+  }

--- a/lib_base/src/main/java/com/mredrock/cyxbs/lib/base/utils/RxjavaLifecycle.kt
+++ b/lib_base/src/main/java/com/mredrock/cyxbs/lib/base/utils/RxjavaLifecycle.kt
@@ -1,0 +1,91 @@
+package com.mredrock.cyxbs.lib.base.utils
+
+import io.reactivex.rxjava3.core.*
+import io.reactivex.rxjava3.disposables.Disposable
+
+/**
+ * 实现该接口，即代表该类支持自动关闭 Rxjava
+ *
+ * ## 为什么不放到 lib_utils 中？
+ * 如果放到 lib_utils 中，在值依赖 lib_base 的时候会出现无法继承 BaseActivity 的情况
+ *
+ * 所以要求 base 类实现的接口尽量不要放在其他模块内
+ */
+interface RxjavaLifecycle {
+  
+  /**
+   * 请把他们放在一个数组中，并在合适的时候关闭
+   */
+  fun onAddRxjava(disposable: Disposable)
+  
+  fun <T : Any> Single<T>.safeSubscribeBy(
+    onError: (Throwable) -> Unit = {},
+    onSuccess: (T) -> Unit = {}
+  ): Disposable = subscribe(onSuccess, onError).also { onAddRxjava(it) }
+  
+  @Deprecated(
+    "该类已实现 Rxjava 的生命周期，请使用 safeSubscribeBy() 代替",
+    ReplaceWith("safeSubscribeBy()"))
+  fun <T : Any> Single<T>.unsafeSubscribeBy(
+    onError: (Throwable) -> Unit = {},
+    onSuccess: (T) -> Unit = {}
+  ): Disposable = subscribe(onSuccess, onError)
+  
+  fun <T : Any> Maybe<T>.safeSubscribeBy(
+    onError: (Throwable) -> Unit = {},
+    onComplete: () -> Unit = {},
+    onSuccess: (T) -> Unit = {}
+  ): Disposable = subscribe(onSuccess, onError).also { onAddRxjava(it) }
+  
+  @Deprecated(
+    "该类已实现 Rxjava 的生命周期，请使用 safeSubscribeBy() 代替",
+    ReplaceWith("safeSubscribeBy()"))
+  fun <T : Any> Maybe<T>.unsafeSubscribeBy(
+    onError: (Throwable) -> Unit = {},
+    onComplete: () -> Unit = {},
+    onSuccess: (T) -> Unit = {}
+  ): Disposable = subscribe(onSuccess, onError, onComplete)
+  
+  fun <T : Any> Observable<T>.safeSubscribeBy(
+    onError: (Throwable) -> Unit = {},
+    onComplete: () -> Unit = {},
+    onNext: (T) -> Unit = {}
+  ): Disposable = subscribe(onNext, onError, onComplete).also { onAddRxjava(it) }
+  
+  @Deprecated(
+    "该类已实现 Rxjava 的生命周期，请使用 safeSubscribeBy() 代替",
+    ReplaceWith("safeSubscribeBy()"))
+  fun <T : Any> Observable<T>.unsafeSubscribeBy(
+    onError: (Throwable) -> Unit = {},
+    onComplete: () -> Unit = {},
+    onNext: (T) -> Unit = {}
+  ): Disposable = subscribe(onNext, onError, onComplete)
+  
+  fun <T : Any> Flowable<T>.safeSubscribeBy(
+    onError: (Throwable) -> Unit = {},
+    onComplete: () -> Unit = {},
+    onNext: (T) -> Unit = {}
+  ): Disposable = subscribe(onNext, onError, onComplete).also { onAddRxjava(it) }
+  
+  @Deprecated(
+    "该类已实现 Rxjava 的生命周期，请使用 safeSubscribeBy() 代替",
+    ReplaceWith("safeSubscribeBy()"))
+  fun <T : Any> Flowable<T>.unsafeSubscribeBy(
+    onError: (Throwable) -> Unit = {},
+    onComplete: () -> Unit = {},
+    onNext: (T) -> Unit = {}
+  ): Disposable = subscribe(onNext, onError, onComplete)
+  
+  fun Completable.safeSubscribeBy(
+    onError: (Throwable) -> Unit = {},
+    onComplete: () -> Unit = {},
+  ): Disposable = subscribe(onComplete, onError).also { onAddRxjava(it) }
+  
+  @Deprecated(
+    "该类已实现 Rxjava 的生命周期，请使用 safeSubscribeBy() 代替",
+    ReplaceWith("safeSubscribeBy()"))
+  fun Completable.unsafeSubscribeBy(
+    onError: (Throwable) -> Unit = {},
+    onComplete: () -> Unit = {},
+  ): Disposable = subscribe(onComplete, onError)
+}

--- a/lib_base/src/main/java/com/mredrock/cyxbs/lib/base/utils/ToastUtils.kt
+++ b/lib_base/src/main/java/com/mredrock/cyxbs/lib/base/utils/ToastUtils.kt
@@ -1,0 +1,29 @@
+package com.mredrock.cyxbs.lib.base.utils
+
+import android.widget.Toast
+import androidx.annotation.StringRes
+import com.mredrock.cyxbs.lib.utils.extensions.CyxbsToast
+import com.mredrock.cyxbs.lib.utils.extensions.appContext
+
+/**
+ * Toast 工具类接口
+ *
+ * ## 为什么不放到 lib_utils 中？
+ * 如果放到 lib_utils 中，在值依赖 lib_base 的时候会出现无法继承 BaseActivity 的情况
+ *
+ * 所以要求 base 类实现的接口尽量不要放在其他模块内
+ */
+interface ToastUtils {
+  /**
+   * 已自带处于其他线程时自动切换至主线程发送
+   */
+  fun toast(s: CharSequence?) {
+    CyxbsToast.show(appContext, s, Toast.LENGTH_SHORT)
+  }
+  fun toastLong(s: CharSequence?) {
+    CyxbsToast.show(appContext, s, Toast.LENGTH_LONG)
+  }
+  fun String.toast() = toast(this)
+  fun String.toastLong() = toastLong(this)
+  fun toast(@StringRes id: Int) = toast(appContext.getString(id))
+}

--- a/lib_utils/src/main/java/com/mredrock/cyxbs/lib/utils/extensions/Exception.kt
+++ b/lib_utils/src/main/java/com/mredrock/cyxbs/lib/utils/extensions/Exception.kt
@@ -1,0 +1,47 @@
+package com.mredrock.cyxbs.lib.utils.extensions
+
+import kotlin.reflect.KClass
+
+/**
+ * 配合 Rxjava 和 Flow 使用 DSL 处理异常的工具类
+ *
+ * @author 985892345 (Guo Xiangrui)
+ * @email guo985892345@foxmail.com
+ * @date 2022/8/28 14:31
+ */
+
+open class ExceptionResult<Emitter>(
+  val error: Throwable,
+  val emitter: Emitter
+) {
+  
+  /**
+   * 处理 [T] 类型的异常
+   * ```
+   * NullPointerException::class.catch {
+   *     val exception = it // 闭包里面的 it 就是 NullPointerException
+   *     val emitter = this // 闭包里面的 this 是发射器，用于重新发送值给下游
+   * }
+   * ```
+   */
+  inline infix fun <reified T : Throwable> KClass<T>.catch(
+    action: Emitter.(T) -> Unit
+  ): KClass<T> {
+    if (error is T) {
+      action.invoke(emitter, error)
+    }
+    return this
+  }
+  
+  /**
+   * 抓取除了 [T] 以外的其他异常
+   */
+  inline infix fun <reified T : Throwable> KClass<T>.catchOther(
+    action: Emitter.(Throwable) -> Unit
+  ): KClass<T> {
+    if (error !is T) {
+      action.invoke(emitter, error)
+    }
+    return this
+  }
+}

--- a/lib_utils/src/main/java/com/mredrock/cyxbs/lib/utils/extensions/Rxjava.kt
+++ b/lib_utils/src/main/java/com/mredrock/cyxbs/lib/utils/extensions/Rxjava.kt
@@ -1,259 +1,90 @@
+@file:Suppress("HasPlatformType")
+
 package com.mredrock.cyxbs.lib.utils.extensions
 
-import com.mredrock.cyxbs.lib.utils.network.ApiException
-import com.mredrock.cyxbs.lib.utils.network.ApiStatus
-import com.mredrock.cyxbs.lib.utils.network.ApiWrapper
 import io.reactivex.rxjava3.core.*
 import io.reactivex.rxjava3.disposables.Disposable
+import kotlinx.coroutines.flow.Flow
 
 /**
- * # 示例代码
- * ```
- * ApiService.INSTANCE.getXXX()
- *     .subscribeOn(Schedulers.io())  // 线程切换
- *     .observeOn(AndroidSchedulers.mainThread())
- *     .mapOrCatchApiException {      // 当 errorCode 的值不为成功时抛错，并处理错误
- *         // 处理 ApiException 错误
- *     }
- *     .unSafeSubscribeBy {             // 如果是网络连接错误，则这里会默认处理
- *         // 成功的时候
- *     }
- *     // ViewModel 中带有的自动回收，直接使用 ViewModel 里面的 safeSubscribeBy 方法即可
- * ```
- *
- * # 其他注意事项
- * ## Rxjava 的下游没任何输出（怎么处理断网时的 HttpException）
- *
- * 大概率是你直接用了 [mapOrCatchApiException]，而它只会处理 [ApiException] ，如果你要处理其他网络错误，
- * 请把 [mapOrCatchApiException] 替换为 [mapOrThrowApiException]：
- * ```
- *     .mapOrThrowApiException()
- *     .doOnError {
- *         if (it is ApiException) {
- *             // 处理 ApiException 错误
- *         } else {
- *             // 处理其他网络错误
- *         }
- *     }
- * ```
+ * 如果你要看网络请求相关的示例代码，请移步 network/ApiRxjava
  *
  * @author 985892345 (Guo Xiangrui)
  * @email 2767465918@qq.com
  * @date 2022/5/30 10:12
  */
 
-fun <T : ApiStatus> Single<T>.throwApiExceptionIfFail(): Single<T> {
-  return doOnSuccess { it.throwApiExceptionIfFail() }
-}
 
-fun <T : ApiStatus> Maybe<T>.throwApiExceptionIfFail(): Maybe<T> {
-  return doOnSuccess { it.throwApiExceptionIfFail() }
-}
-
-fun <T : ApiStatus> Observable<T>.throwApiExceptionIfFail(): Observable<T> {
-  return doOnNext { it.throwApiExceptionIfFail() }
-}
-
-fun <T : ApiStatus> Flowable<T>.throwApiExceptionIfFail(): Flowable<T> {
-  return doOnNext { it.throwApiExceptionIfFail() }
-}
-
-fun <E : Any, T : ApiWrapper<E>> Single<T>.mapOrThrowApiException(): Single<E> {
-  return throwApiExceptionIfFail()
-    .map { it.data }
-}
-
-fun <E : Any, T : ApiWrapper<E>> Maybe<T>.mapOrThrowApiException(): Maybe<E> {
-  return throwApiExceptionIfFail()
-    .map { it.data }
-}
-
-fun <E : Any, T : ApiWrapper<E>> Observable<T>.mapOrThrowApiException(): Observable<E> {
-  return throwApiExceptionIfFail()
-    .map { it.data }
-}
-
-fun <E : Any, T : ApiWrapper<E>> Flowable<T>.mapOrThrowApiException(): Flowable<E> {
-  return throwApiExceptionIfFail()
-    .map { it.data }
-}
-
-fun <T : ApiStatus> Single<T>.catchApiException(
-  func: (ApiException) -> Unit
-): Single<T> {
-  return throwApiExceptionIfFail()
-    .doOnError {
-      if (it is ApiException) func.invoke(it)
+/**
+ * 转换为 data 并使用 DSL 写法来处理异常
+ *
+ * # 详细用法请查看 [Flow.interceptException]，注意事项也与 Flow 一致
+ */
+fun <T : Any> Single<T>.interceptException(
+  action: ExceptionResult<SingleEmitter<T>>.() -> Unit
+) : Single<T> {
+  return onErrorResumeNext { error ->
+    Single.create {
+      ExceptionResult(error, it).action()
     }
+  }
 }
-
-fun <T : ApiStatus> Maybe<T>.catchApiException(
-  func: (ApiException) -> Unit
-): Maybe<T> {
-  return throwApiExceptionIfFail()
-    .doOnError {
-      if (it is ApiException) func.invoke(it)
+fun <T : Any> Maybe<T>.interceptException(
+  action: ExceptionResult<MaybeEmitter<T>>.() -> Unit
+) : Maybe<T> {
+  return onErrorResumeNext { error ->
+    Maybe.create {
+      ExceptionResult<MaybeEmitter<T>>(error, it).action()
     }
+  }
 }
-
-fun <T : ApiStatus> Observable<T>.catchApiException(
-  func: (ApiException) -> Unit
-): Observable<T> {
-  return throwApiExceptionIfFail()
-    .doOnError {
-      if (it is ApiException) func.invoke(it)
+fun <T : Any> Observable<T>.interceptException(
+  action: ExceptionResult<ObservableEmitter<T>>.() -> Unit
+) : Observable<T> {
+  return onErrorResumeNext { error ->
+    Observable.create {
+      ExceptionResult<ObservableEmitter<T>>(error, it).action()
     }
+  }
 }
-
-fun <T : ApiStatus> Flowable<T>.catchApiException(
-  func: (ApiException) -> Unit
-): Flowable<T> {
-  return throwApiExceptionIfFail()
-    .doOnError {
-      if (it is ApiException) func.invoke(it)
+fun Completable.interceptException(
+  action: ExceptionResult<CompletableEmitter>.() -> Unit
+) : Completable {
+  return onErrorResumeNext { error ->
+    Completable.create {
+      ExceptionResult<CompletableEmitter>(error, it).action()
     }
-}
-
-fun <E : Any, T : ApiWrapper<E>> Single<T>.mapOrCatchApiException(
-  func: (ApiException) -> Unit
-): Single<E> {
-  return catchApiException(func)
-    .map { it.data }
-}
-
-fun <E : Any, T : ApiWrapper<E>> Maybe<T>.mapOrCatchApiException(
-  func: (ApiException) -> Unit
-): Maybe<E> {
-  return catchApiException(func)
-    .map { it.data }
-}
-
-fun <E : Any, T : ApiWrapper<E>> Observable<T>.mapOrCatchApiException(
-  func: (ApiException) -> Unit
-): Observable<E> {
-  return catchApiException(func)
-    .map { it.data }
-}
-
-fun <E : Any, T : ApiWrapper<E>> Flowable<T>.mapOrCatchApiException(
-  func: (ApiException) -> Unit
-): Flowable<E> {
-  return catchApiException(func)
-    .map { it.data }
+  }
 }
 
 /**
- * 其实这个命名是直接抄的掌邮的，最开始这个 safe 的意思是如果直接使用一个形参的 subscribe(onSuccess)，
+ * 这个命名与之前的 lib_common 中有些区别，common 中那个 safe 的意思是如果直接使用一个形参的 subscribe(onSuccess)，
  * 在收到上游错误时 Rxjava 会把错误直接抛给整个应用来处理，如果你没有配置 Rxjava 的全局报错，应用会直接闪退，
- * safe 就是指这个安全问题，目前因为生命周期问题，所以改名 unsafe
+ * common 中 safe 就是指上述安全问题
+ *
+ * 目前这个 safe 表示带有生命周期的安全订阅
  */
 
 fun <T : Any> Single<T>.unsafeSubscribeBy(
   onError: (Throwable) -> Unit = {},
   onSuccess: (T) -> Unit = {}
 ): Disposable = subscribe(onSuccess, onError)
-
 fun <T : Any> Maybe<T>.unsafeSubscribeBy(
   onError: (Throwable) -> Unit = {},
   onComplete: () -> Unit = {},
   onSuccess: (T) -> Unit = {}
 ): Disposable = subscribe(onSuccess, onError, onComplete)
-
 fun <T : Any> Observable<T>.unsafeSubscribeBy(
   onError: (Throwable) -> Unit = {},
   onComplete: () -> Unit = {},
   onNext: (T) -> Unit = {}
 ): Disposable = subscribe(onNext, onError, onComplete)
-
 fun <T : Any> Flowable<T>.unsafeSubscribeBy(
   onError: (Throwable) -> Unit = {},
   onComplete: () -> Unit = {},
   onNext: (T) -> Unit = {}
 ): Disposable = subscribe(onNext, onError, onComplete)
-
 fun Completable.unsafeSubscribeBy(
   onError: (Throwable) -> Unit = {},
   onComplete: () -> Unit = {},
 ): Disposable = subscribe(onComplete, onError)
-
-/**
- * 实现该接口，即代表该类支持自动关闭 Rxjava
- */
-interface RxjavaLifecycle {
-  
-  /**
-   * 请把他们放在一个数组中，并在合适的时候关闭
-   */
-  fun onAddRxjava(disposable: Disposable)
-  
-  fun <T : Any> Single<T>.safeSubscribeBy(
-    onError: (Throwable) -> Unit = {},
-    onSuccess: (T) -> Unit = {}
-  ): Disposable = subscribe(onSuccess, onError).also { onAddRxjava(it) }
-  
-  @Deprecated(
-    "该类已实现 Rxjava 的生命周期，请使用 safeSubscribeBy() 代替",
-    ReplaceWith("safeSubscribeBy()"))
-  fun <T : Any> Single<T>.unsafeSubscribeBy(
-    onError: (Throwable) -> Unit = {},
-    onSuccess: (T) -> Unit = {}
-  ): Disposable = subscribe(onSuccess, onError)
-  
-  fun <T : Any> Maybe<T>.safeSubscribeBy(
-    onError: (Throwable) -> Unit = {},
-    onComplete: () -> Unit = {},
-    onSuccess: (T) -> Unit = {}
-  ): Disposable = subscribe(onSuccess, onError).also { onAddRxjava(it) }
-  
-  @Deprecated(
-    "该类已实现 Rxjava 的生命周期，请使用 safeSubscribeBy() 代替",
-    ReplaceWith("safeSubscribeBy()"))
-  fun <T : Any> Maybe<T>.unsafeSubscribeBy(
-    onError: (Throwable) -> Unit = {},
-    onComplete: () -> Unit = {},
-    onSuccess: (T) -> Unit = {}
-  ): Disposable = subscribe(onSuccess, onError, onComplete)
-  
-  fun <T : Any> Observable<T>.safeSubscribeBy(
-    onError: (Throwable) -> Unit = {},
-    onComplete: () -> Unit = {},
-    onNext: (T) -> Unit = {}
-  ): Disposable = subscribe(onNext, onError, onComplete).also { onAddRxjava(it) }
-  
-  @Deprecated(
-    "该类已实现 Rxjava 的生命周期，请使用 safeSubscribeBy() 代替",
-    ReplaceWith("safeSubscribeBy()"))
-  fun <T : Any> Observable<T>.unsafeSubscribeBy(
-    onError: (Throwable) -> Unit = {},
-    onComplete: () -> Unit = {},
-    onNext: (T) -> Unit = {}
-  ): Disposable = subscribe(onNext, onError, onComplete)
-  
-  fun <T : Any> Flowable<T>.safeSubscribeBy(
-    onError: (Throwable) -> Unit = {},
-    onComplete: () -> Unit = {},
-    onNext: (T) -> Unit = {}
-  ): Disposable = subscribe(onNext, onError, onComplete).also { onAddRxjava(it) }
-  
-  @Deprecated(
-    "该类已实现 Rxjava 的生命周期，请使用 safeSubscribeBy() 代替",
-    ReplaceWith("safeSubscribeBy()"))
-  fun <T : Any> Flowable<T>.unsafeSubscribeBy(
-    onError: (Throwable) -> Unit = {},
-    onComplete: () -> Unit = {},
-    onNext: (T) -> Unit = {}
-  ): Disposable = subscribe(onNext, onError, onComplete)
-  
-  fun Completable.safeSubscribeBy(
-    onError: (Throwable) -> Unit = {},
-    onComplete: () -> Unit = {},
-  ): Disposable = subscribe(onComplete, onError).also { onAddRxjava(it) }
-  
-  @Deprecated(
-    "该类已实现 Rxjava 的生命周期，请使用 safeSubscribeBy() 代替",
-    ReplaceWith("safeSubscribeBy()"))
-  fun Completable.unsafeSubscribeBy(
-    onError: (Throwable) -> Unit = {},
-    onComplete: () -> Unit = {},
-  ): Disposable = subscribe(onComplete, onError)
-}

--- a/lib_utils/src/main/java/com/mredrock/cyxbs/lib/utils/extensions/Toast.kt
+++ b/lib_utils/src/main/java/com/mredrock/cyxbs/lib/utils/extensions/Toast.kt
@@ -1,13 +1,14 @@
 package com.mredrock.cyxbs.lib.utils.extensions
 
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.TextView
 import android.widget.Toast
-import androidx.annotation.StringRes
 import com.mredrock.cyxbs.lib.utils.BuildConfig
 import com.mredrock.cyxbs.lib.utils.R
 
@@ -18,24 +19,29 @@ import com.mredrock.cyxbs.lib.utils.R
  * @date 2022/3/7 17:58
  */
 
+/**
+ * 已自带处于其他线程时自动切换至主线程发送
+ */
 fun toast(s: CharSequence?) {
-  CyxbsToast.show(appContext, s, Toast.LENGTH_SHORT)
+  if (s == null) return
+  if (Thread.currentThread() !== Looper.getMainLooper().thread) {
+    Handler(Looper.getMainLooper()).post { CyxbsToast.show(appContext, s, Toast.LENGTH_SHORT) }
+  } else {
+    CyxbsToast.show(appContext, s, Toast.LENGTH_SHORT)
+  }
 }
 
 fun toastLong(s: CharSequence?) {
-  CyxbsToast.show(appContext, s, Toast.LENGTH_LONG)
+  if (s == null) return
+  if (Thread.currentThread() !== Looper.getMainLooper().thread) {
+    Handler(Looper.getMainLooper()).post { CyxbsToast.show(appContext, s, Toast.LENGTH_LONG) }
+  } else {
+    CyxbsToast.show(appContext, s, Toast.LENGTH_LONG)
+  }
 }
 
 fun String.toast() = toast(this)
 fun String.toastLong() = toastLong(this)
-
-interface ToastUtils {
-  fun toast(s: CharSequence?) = CyxbsToast.show(appContext, s, Toast.LENGTH_SHORT)
-  fun toastLong(s: CharSequence?) = CyxbsToast.show(appContext, s, Toast.LENGTH_LONG)
-  fun String.toast() = toast(this)
-  fun String.toastLong() = toastLong(this)
-  fun toast(@StringRes id: Int) = toast(appContext.getString(id))
-}
 
 class CyxbsToast {
   companion object {
@@ -77,7 +83,7 @@ class CyxbsToast {
       result.setGravity(Gravity.CENTER_HORIZONTAL or Gravity.TOP, 0, height / 8)
       result.show()
     }
-  
+    
     /**
      * 寻找第一个满足条件后的子数组
      */

--- a/lib_utils/src/main/java/com/mredrock/cyxbs/lib/utils/network/ApiException.kt
+++ b/lib_utils/src/main/java/com/mredrock/cyxbs/lib/utils/network/ApiException.kt
@@ -1,7 +1,60 @@
 package com.mredrock.cyxbs.lib.utils.network
 
+import com.google.gson.Gson
+import com.google.gson.JsonSyntaxException
+import com.mredrock.cyxbs.lib.utils.extensions.ExceptionResult
+import okhttp3.ResponseBody
+import retrofit2.HttpException
+import retrofit2.Response
+import kotlin.reflect.KClass
+
 /**
- * ...
+ *
+ * 正常请求后的网络异常
+ *
+ * ## 一、什么情况下是正常请求？
+ * 只有当 Http 状态码为 200 到 299 之间时才能被认为是正常请求，其他状态码会被 Retrofit 之间拦截并抛出 [HttpException]
+ *
+ * ## 二、什么是 Http 状态码？和 status 这个状态码有什么区别？
+ * Http 状态码是公开的规范，各个公司都遵守，返回 200 时表示本次请求成功，
+ * 但 status 这个状态码用于判断本次请求的数据是否成功，属于自定义的一种状态码
+ *
+ * ## 三、有个接口 Http 状态码不返回 200，后端也不去改，该怎么办？
+ * 这种情况属于后端的锅，无论数据是否成功，只要与后端服务器连接成功都应该返回 Http 状态码 200（除去部分服务器的锅返回 4xx），
+ * 如果返回其他的会导致 Retrofit 直接拦截然后抛出错误
+ *
+ * 如果你遇到这种情况，首先让后端去改
+ *
+ * ### 1、在多次交谈无果后，万不得已的情况下，可以采用下面这种写法获取
+ * ```
+ * .doOnError {
+ *     if (it is HttpException) {
+ *         val response = it.response()
+ *         try {
+ *             if (response?.code() == 500) { // 这个不一定是 500，看自己的接口会返回什么
+ *                 val data = Gson().fromJson(response.errorBody().toString(), XXXBean::class.java)
+ *                 // 然后你就可以对这个 data 进行操作了
+ *             }
+ *         } catch (e: JsonSyntaxException) {
+ *             // Gson 出错
+ *         }
+ *     }
+ * }
+ * ```
+ * 目前该逻辑已封装进 Rxjava 和 Flow
+ * ```
+ * .mapOrThrowApiException {
+ *     HttpException<XXXBean>(500) {
+ *         it.xxx
+ *
+ *         emit(it) // 也可以重新发送给下游，但注意这个 it 需要与外面的泛型一致才能发送
+ *         // Flow 使用 emit()，Rxjava 使用 onSuccess()
+ *     }
+ * }
+ * ```
+ *
+ * ### 2、一定要让后端先改！！！（有些老接口采用了上面这种写法，为了兼容，所以老接口就算了）
+ *
  * @author 985892345 (Guo Xiangrui)
  * @email 2767465918@qq.com
  * @date 2022/5/29 23:47
@@ -10,3 +63,85 @@ class ApiException(
   val status: Int,
   val info: String
 ) : RuntimeException("status = $status   info = $info")
+
+@Suppress("FunctionName")
+class ApiExceptionResult<Emitter>(
+  error: Throwable,
+  emitter: Emitter
+) : ExceptionResult<Emitter>(error, emitter) {
+  
+  /**
+   * 只抓取 [ApiException] 异常
+   * @param status 单独处理 [status] 对应的情况。如果传入 -1，则处理全部 status
+   */
+  inline fun ApiException(status: Int = -1, action: Emitter.(ApiException) -> Unit): KClass<ApiException> {
+    return ApiException::class.catch {
+      if (status == -1) action.invoke(this, it)
+      else if (it.status == status) action.invoke(this, it)
+    }
+  }
+  
+  /**
+   * 抓取除了 [ApiException] 外的其他异常
+   */
+  inline fun ApiExceptionExcept(action: Emitter.(Throwable) -> Unit): KClass<ApiException> {
+    return ApiException::class.catchOther(action)
+  }
+  
+  /**
+   * 如果是 [HttpException]，则反序列化 [Response.errorBody] 为 [T]
+   *
+   * ## 注意
+   * 不是很推荐使用，因为这个情况一般是后端的问题，只要与服务器连接成功都该返回 2xx，
+   * 所以请在与后端多次沟通无果后再使用！！！（部分老接口除外）
+   *
+   * @param httpCode 想要处理的 Http 状态码
+   */
+  inline fun <reified T : Any> HttpExceptionData(
+    httpCode: Int,
+    action: Emitter.(T) -> Unit
+  ): KClass<HttpException> = HttpException::class.fromJson(T::class, httpCode, action)
+  
+  inline fun HttpExceptionBody(
+    httpCode: Int,
+    action: Emitter.(ResponseBody) -> Unit
+  ): KClass<HttpException> = HttpException::class.errorBody(httpCode, action)
+  
+  /**
+   * 用于后端异常返回，Http 状态码不为 2xx 时
+   *
+   * 不是很推荐使用，因为这个情况一般是后端的问题，只要与服务器连接成功都该返回 2xx，
+   * 所以请在与后端多次沟通无果后再使用！！！（部分老接口除外）
+   *
+   * @param httpCode 想要处理的 Http 状态码
+   */
+  inline fun <T : Any> KClass<HttpException>.fromJson(
+    clazz: KClass<T>,
+    httpCode: Int,
+    action: Emitter.(T) -> Unit
+  ): KClass<HttpException> {
+    errorBody(httpCode) {
+      try {
+        action.invoke(emitter, Gson().fromJson(it.toString(), clazz.java))
+      } catch (e : JsonSyntaxException) {
+        e.printStackTrace()
+      }
+    }
+    return this
+  }
+  
+  inline fun KClass<HttpException>.errorBody(
+    httpCode: Int,
+    action: Emitter.(ResponseBody) -> Unit
+  ): KClass<HttpException> {
+    if (error is HttpException) {
+      if (error.code() == httpCode) {
+        val errorBody = error.response()?.errorBody()
+        if (errorBody != null) {
+          action.invoke(emitter, errorBody)
+        }
+      }
+    }
+    return this
+  }
+}

--- a/lib_utils/src/main/java/com/mredrock/cyxbs/lib/utils/network/ApiFlow.kt
+++ b/lib_utils/src/main/java/com/mredrock/cyxbs/lib/utils/network/ApiFlow.kt
@@ -1,0 +1,116 @@
+package com.mredrock.cyxbs.lib.utils.network
+
+import com.mredrock.cyxbs.lib.utils.extensions.interceptException
+import kotlinx.coroutines.flow.*
+
+/**
+ * ...
+ *
+ * @author 985892345 (Guo Xiangrui)
+ * @email guo985892345@foxmail.com
+ * @date 2022/8/28 15:16
+ */
+
+/**
+ * # 网络请求示例代码
+ * 抓取 http 中的报错，并装换为直接包含 data 的 Flow
+ * 建议配合 BaseViewModel 中 collectLaunch 一起食用
+ * ```
+ * flow {
+ *     emit(FindApiServices.INSTANCE.getStudents(stu))
+ * }.onStart {                  // 开始
+ *     //...
+ * }.onCompletion {             // 结束
+ *     //...
+ * }.mapOrInterceptException {  // 当 status 的值不为成功时抛错，并处理错误
+ *
+ *     toast("捕捉全部异常")      // 直接写的话可以处理全部异常
+ *
+ *     ApiException {
+ *         // 处理全部 ApiException 错误
+ *     }.catchOther {
+ *         // 处理非 ApiException 的其他异常
+ *     }
+ *
+ *     ApiExceptionExcept {
+ *         // 这样写可以直接处理非 ApiException 的其他异常
+ *     }
+ *
+ *     ApiException(10010) {
+ *         // 单独处理 status 为 10010 时的 ApiException
+ *     }
+ *
+ *     HttpExceptionData<XXXBean>(500) {
+ *         // 处理 HttpException 并反序列化 json 为 XXXBean
+ *
+ *         emit(it) // 也可以重新发送 XXXBean 给下游，但注意 XXXBean 需要数据流中的泛型一致才能发送
+ *     }
+ *
+ *     HttpExceptionBody(500) {
+ *         // 处理 HttpException，但只获取 errorBody
+ *     }
+ *
+ * }.collectLaunch {            // 收集，注意：collectLaunch() 是专门封装了的一个方法
+ *     _studentData.emit(it)
+ * }
+ * ```
+ *
+ * ## 网络请求怎么直接返回 Flow ?
+ *
+ * 由于目前 Retrofit 官方没有直接给出 Flow 的 adapter，如果有必要使用 Flow 的话，
+ * 可以暂时使用 Observable 来转成 Flow
+ *
+ * **需要先引入依赖：dependCoroutinesRx3()**
+ * ```
+ * FindApiServices.INSTANCE.getStudents(stu)
+ *     .subscribeOn(Schedulers.io()) // 线程切换（必要）
+ *     .asFlow()                     // 转换成 Flow
+ * ```
+ */
+
+/**
+ * 转换为 data 并使用 DSL 写法来处理异常
+ *
+ * # 详细用法请查看 [Flow.interceptException]
+ *
+ * - [IApiWrapper] 推荐使用 [mapOrInterceptException] 方法
+ * - [IApiStatus] 使用 [throwOrInterceptException] 方法
+ */
+fun <Data, T : IApiWrapper<Data>> Flow<T>.mapOrInterceptException(
+  action: ApiExceptionResult<FlowCollector<Data>>.() -> Unit
+): Flow<Data> {
+  return mapOrThrowApiException()
+    .catch {
+      ApiExceptionResult(it, this).action()
+    }
+}
+
+fun <T : IApiStatus> Flow<T>.throwOrInterceptException(
+  action: ApiExceptionResult<FlowCollector<T>>.() -> Unit
+): Flow<T> {
+  return throwApiExceptionIfFail()
+    .catch {
+      ApiExceptionResult(it, this).action()
+    }
+}
+
+
+
+
+/**
+ * 装换为 [Data] 并检查数据中的状态码是否有问题，有就抛出异常
+ *
+ * 注意：数据中的状态码是 status 字段，不是 Http 状态码，这两个状态码不要混淆了
+ */
+fun <Data, T : IApiWrapper<Data>> Flow<T>.mapOrThrowApiException(): Flow<Data> {
+  return throwApiExceptionIfFail()
+    .map {
+      it.data
+    }
+}
+
+fun <T : IApiStatus> Flow<T>.throwApiExceptionIfFail(): Flow<T> {
+  return onEach {
+    it.throwApiExceptionIfFail()
+  }
+}

--- a/lib_utils/src/main/java/com/mredrock/cyxbs/lib/utils/network/ApiGenerator.kt
+++ b/lib_utils/src/main/java/com/mredrock/cyxbs/lib/utils/network/ApiGenerator.kt
@@ -1,8 +1,6 @@
 package com.mredrock.cyxbs.lib.utils.network
 
 import com.mredrock.cyxbs.common.network.ApiGenerator
-import com.mredrock.cyxbs.lib.utils.extensions.mapOrThrowApiException
-import com.mredrock.cyxbs.lib.utils.extensions.mapOrCatchApiException
 import kotlin.reflect.KClass
 
 /**
@@ -37,30 +35,13 @@ import kotlin.reflect.KClass
  * ApiService.INSTANCE.getXXX()
  *     .subscribeOn(Schedulers.io())  // 线程切换
  *     .observeOn(AndroidSchedulers.mainThread())
- *     .mapOrCatchApiException {      // 当 errorCode 的值不为成功时抛错，并处理错误
- *         // 处理 ApiException 错误，注意：这里并不会处理断网时的 HttpException
+ *     .mapOrInterceptException {     // 当 errorCode 的值不为成功时抛错，并拦截异常
+ *         // 这里面可以使用 DSL 写法，更多详细用法请看该方法注释
  *     }
  *     .safeSubscribeBy {            // 如果是网络连接错误，则这里会默认处理
  *         // 成功的时候
  *     }
  * ```
- *
- * # 其他注意事项
- * ## Rxjava 或 Flow 的下游没任何输出（怎么处理断网时的 HttpException）
- *
- * 大概率是你直接用了 [mapOrCatchApiException]，而它只会处理 [ApiException]，如果你要处理其他网络错误，
- * 请把 [mapOrCatchApiException] 替换为 [mapOrThrowApiException]：
- * ```
- *     .mapOrThrowApiException()
- *     .doOnError {                    // Flow 操作符为 catch
- *         if (it is ApiException) {
- *             // 处理 ApiException 错误
- *         } else {
- *             // 处理其他网络错误
- *         }
- *     }
- * ```
- *
  *
  * @author 985892345 (Guo Xiangrui)
  * @email 2767465918@qq.com

--- a/lib_utils/src/main/java/com/mredrock/cyxbs/lib/utils/network/ApiRxjava.kt
+++ b/lib_utils/src/main/java/com/mredrock/cyxbs/lib/utils/network/ApiRxjava.kt
@@ -1,0 +1,104 @@
+@file:Suppress("HasPlatformType")
+
+package com.mredrock.cyxbs.lib.utils.network
+
+import com.mredrock.cyxbs.lib.utils.extensions.interceptException
+import io.reactivex.rxjava3.core.Single
+import io.reactivex.rxjava3.core.SingleEmitter
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * # 网络请求示例代码
+ * ```
+ * ApiService.INSTANCE.getXXX()
+ *     .subscribeOn(Schedulers.io())  // 线程切换
+ *     .observeOn(AndroidSchedulers.mainThread())
+ *     .mapOrCatchException {         // 当 status 的值不为成功时抛错，并处理错误
+ *
+ *         toast("捕捉全部异常")        // 直接写的话可以处理全部异常
+ *
+ *         ApiException {
+ *             // 处理全部 ApiException 错误
+ *         }.catchOther {
+ *             // 处理非 ApiException 的其他异常
+ *         }
+ *
+ *         ApiExceptionExcept {
+ *             // 这样写可以直接处理非 ApiException 的其他异常
+ *         }
+ *
+ *         ApiException(10010) {
+ *             // 单独处理 status 为 10010 时的 ApiException
+ *         }
+ *
+ *         HttpExceptionData<XXXBean>(500) {
+ *             // 处理 HttpException 并反序列化 json 为 XXXBean
+ *
+ *             onSuccess(it) // 也可以重新发送 XXXBean 给下游，但注意 XXXBean 需要与数据流中的泛型一致才能发送
+ *         }
+ *
+ *         HttpExceptionBody(500) {
+ *             // 处理 HttpException，但只获取 errorBody
+ *         }
+ *     }
+ *     .unsafeSubscribeBy {           // 这里默认处理了所有异常，防止 Rxjava 把异常往默认全局异常处理抛
+ *         // 成功的时候                // 因为掌邮没有使用全局异常处理，如果抛给全局异常了，会导致应用崩溃
+ *     }
+ *     // ViewModel 中带有的自动回收，直接使用 ViewModel 里面的 safeSubscribeBy 方法即可
+ * ```
+ *
+ * 由于网络请求是单发数据，所以使用 Single 即可，就没有添加其他数据流的扩展
+ *
+ * @author 985892345 (Guo Xiangrui)
+ * @email 2767465918@qq.com
+ * @date 2022/5/30 10:12
+ */
+
+
+/**
+ * 转换为 data 并使用 DSL 写法来处理异常
+ *
+ * # 详细用法请查看 [Flow.interceptException]
+ *
+ * - [IApiWrapper] 推荐使用 [mapOrInterceptException] 方法
+ * - [IApiStatus] 使用 [throwOrInterceptException] 方法
+ */
+fun <Data : Any, T : IApiWrapper<Data>> Single<T>.mapOrInterceptException(
+  action: ApiExceptionResult<SingleEmitter<Data>>.() -> Unit
+) : Single<Data> {
+  return mapOrThrowApiException().onErrorResumeNext { error ->
+    Single.create {
+      ApiExceptionResult(error, it).action()
+    }
+  }
+}
+
+fun <T : IApiStatus> Single<T>.throwOrInterceptException(
+  action: ApiExceptionResult<SingleEmitter<T>>.() -> Unit
+) : Single<T> {
+  return throwApiExceptionIfFail().onErrorResumeNext { error ->
+    Single.create {
+      ApiExceptionResult(error, it).action()
+    }
+  }
+}
+
+
+
+/**
+ * 装换为 [Data] 并检查数据中的状态码是否有问题，有就抛出异常
+ *
+ * 注意：数据中的状态码是 status 字段，不是 Http 状态码，这两个状态码不要混淆了
+ */
+fun <Data : Any, T : IApiWrapper<Data>> Single<T>.mapOrThrowApiException(): Single<Data> {
+  return throwApiExceptionIfFail()
+    .map {
+      it.data
+    }
+}
+
+fun <T : IApiStatus> Single<T>.throwApiExceptionIfFail(): Single<T> {
+  return doOnSuccess {
+    it.throwApiExceptionIfFail()
+  }
+}

--- a/lib_utils/src/main/java/com/mredrock/cyxbs/lib/utils/network/ApiWrapper.kt
+++ b/lib_utils/src/main/java/com/mredrock/cyxbs/lib/utils/network/ApiWrapper.kt
@@ -5,17 +5,24 @@ import java.io.Serializable
 import kotlin.jvm.Throws
 
 /**
- * [ApiWrapper] 里面封装了 [data]、[status]、[info] 字段，是为了统一网络请求数据的最外层结构，
- * 如果你遇到了 json 报错，可能是你数据类写错了，只需要提供 [data] 对应的类即可
+ * [ApiWrapper] 里面封装了 [data]、[status]、[info] 字段，是为了统一网络请求数据的最外层结构
+ *
+ * ## 注意
+ * - 如果你遇到了 json 报错，可能是你数据类写错了，只需要提供 [data] 对应的类即可
+ * - 如果你的网络请求数据类有其他变量，请使用 [IApiWrapper] 这个接口
  *
  * @author 985892345 (Guo Xiangrui)
  * @email 2767465918@qq.com
  * @date 2022/5/29 23:06
  */
-open class ApiWrapper<T> (
+data class ApiWrapper<T>(
   @SerializedName("data")
-  val data: T,
-) : Serializable, ApiStatus()
+  override val data: T,
+  @SerializedName("status")
+  override val status: Int,
+  @SerializedName("info")
+  override val info: String
+) : IApiWrapper<T>
 
 /**
  * 没有 data 字段的接口数据包裹类
@@ -26,12 +33,20 @@ open class ApiWrapper<T> (
  * - 如果需要添加且不是老接口，那说明是后端没有遵守规范，让后端自己改接口
  * - 如果是老接口，请自己使用 map 操作符判断
  */
-open class ApiStatus(
+data class ApiStatus(
   @SerializedName("status")
-  val status: Int = -1,
+  override val status: Int,
   @SerializedName("info")
-  val info: String = ""
-) : Serializable {
+  override val info: String
+) : IApiStatus
+
+interface IApiWrapper<T> : IApiStatus {
+  val data: T
+}
+
+interface IApiStatus : Serializable {
+  val status: Int
+  val info: String
   
   /**
    * 数据的状态码
@@ -39,9 +54,15 @@ open class ApiStatus(
    * 与后端规定了 10000 为 数据请求成功
    *
    * 注意区分：数据 Http 状态码 与 数据状态码
+   *
+   * 对于 [status] 不为 10000 时，建议采用下面这种写法来处理
+   * ```
+   *
+   * ```
    */
   fun isSuccess(): Boolean {
-    return status == 10000 // 请不要私自加其他的成功状态！！！
+    // 10000 是 21 年后的新规定，200 是以前老接口的规定
+    return status == 10000 || status == 200 // 请不要私自加其他的成功状态！！！
   }
   
   @Throws(ApiException::class)

--- a/module_login/src/main/java/com/mredrock/cyxbs/login/page/useragree/UserAgreeActivity.kt
+++ b/module_login/src/main/java/com/mredrock/cyxbs/login/page/useragree/UserAgreeActivity.kt
@@ -5,13 +5,8 @@ import android.view.View
 import android.widget.ProgressBar
 import androidx.recyclerview.widget.RecyclerView
 import com.mredrock.cyxbs.lib.base.ui.BaseActivity
-import com.mredrock.cyxbs.lib.utils.extensions.gone
-import com.mredrock.cyxbs.lib.utils.extensions.mapOrCatchApiException
-import com.mredrock.cyxbs.lib.utils.extensions.setOnSingleClickListener
-import com.mredrock.cyxbs.lib.utils.network.CommonApiService
-import com.mredrock.cyxbs.lib.utils.network.DownMessage
-import com.mredrock.cyxbs.lib.utils.network.DownMessageParams
-import com.mredrock.cyxbs.lib.utils.network.commonApi
+import com.mredrock.cyxbs.lib.utils.extensions.*
+import com.mredrock.cyxbs.lib.utils.network.*
 import com.mredrock.cyxbs.login.R
 import com.mredrock.cyxbs.login.page.login.adapter.UserAgreementAdapter
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
@@ -34,30 +29,37 @@ class UserAgreeActivity : BaseActivity() {
             finish()
         }
     
-        // 因为界面简单，所以就没有必要使用 ViewModel，使用最原始的保存数据就可以了
+        // 因为界面简单，所以就没有必要使用 ViewModel，使用最原始的保存数据方式就可以了
         if (savedInstanceState == null) {
-            val startTime = System.currentTimeMillis()
-            CommonApiService::class.commonApi
-                .getDownMessage(DownMessageParams("zscy-main-userAgreement"))
-                .subscribeOn(Schedulers.io())
-                .delay(
-                    // 有时候网路慢会转一下圈圈，但是有时候网络快，圈圈就像是闪了一下，像bug，就让它最少转一秒吧
-                    (System.currentTimeMillis() - startTime).let { if (it > 1000) 0 else it },
-                    TimeUnit.MILLISECONDS
-                ).observeOn(AndroidSchedulers.mainThread())
-                .mapOrCatchApiException {
-                    toast("网络似乎开小差了~")
-                }.safeSubscribeBy {
-                    mDownMessage = it
-                    mProgressBar.gone()
-                    mRecyclerView.adapter = UserAgreementAdapter(it.textList)
-                }
+            getDownMessage()
         } else {
+            // savedInstanceState 不为 null 时说明界面重新被异常摧毁重建了
             val downMessage = savedInstanceState.getSerializable(this::mDownMessage.name) as DownMessage?
             if (downMessage != null) {
                 mRecyclerView.adapter = UserAgreementAdapter(downMessage.textList)
+            } else {
+                getDownMessage()
             }
         }
+    }
+    
+    private fun getDownMessage() {
+        val startTime = System.currentTimeMillis()
+        CommonApiService::class.commonApi
+            .getDownMessage(DownMessageParams("zscy-main-userAgreement"))
+            .subscribeOn(Schedulers.io())
+            .delay(
+                // 有时候网路慢会转一下圈圈，但是有时候网络快，圈圈就像是闪了一下，像bug，就让它最少转一秒吧
+                (System.currentTimeMillis() - startTime).let { if (it > 1000) 0 else it },
+                TimeUnit.MILLISECONDS
+            ).observeOn(AndroidSchedulers.mainThread())
+            .mapOrInterceptException {
+                toast("网络似乎开小差了~")
+            }.safeSubscribeBy {
+                mDownMessage = it
+                mProgressBar.gone()
+                mRecyclerView.adapter = UserAgreementAdapter(it.textList)
+            }
     }
     
     override fun onSaveInstanceState(outState: Bundle) {

--- a/module_mine/src/main/java/com/mredrock/cyxbs/mine/page/security/viewmodel/FindPasswordByIdsViewModel.kt
+++ b/module_mine/src/main/java/com/mredrock/cyxbs/mine/page/security/viewmodel/FindPasswordByIdsViewModel.kt
@@ -3,9 +3,9 @@ package com.mredrock.cyxbs.mine.page.security.viewmodel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.mredrock.cyxbs.lib.base.ui.BaseViewModel
-import com.mredrock.cyxbs.lib.utils.extensions.mapOrThrowApiException
-import com.mredrock.cyxbs.lib.utils.extensions.throwApiExceptionIfFail
 import com.mredrock.cyxbs.lib.utils.network.ApiGenerator
+import com.mredrock.cyxbs.lib.utils.network.mapOrInterceptException
+import com.mredrock.cyxbs.lib.utils.network.throwOrInterceptException
 import com.mredrock.cyxbs.mine.network.ApiService
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.schedulers.Schedulers
@@ -55,8 +55,7 @@ class FindPasswordByIdsViewModel : BaseViewModel() {
             .getIdsCode(requestBody)
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
-            .mapOrThrowApiException()
-            .doOnError {
+            .mapOrInterceptException {
                 _isGetCodeSuccess.postValue(false)
             }
             .safeSubscribeBy {
@@ -75,8 +74,7 @@ class FindPasswordByIdsViewModel : BaseViewModel() {
             .changePasswordByIds(stuNum, newPassword, mCode)
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
-            .throwApiExceptionIfFail()
-            .doOnError {
+            .throwOrInterceptException {
                 _isChangeSuccess.postValue(false)
             }
             .safeSubscribeBy {

--- a/module_sport/src/main/java/com/mredrock/cyxbs/sport/model/SportRepository.kt
+++ b/module_sport/src/main/java/com/mredrock/cyxbs/sport/model/SportRepository.kt
@@ -9,6 +9,7 @@ import com.mredrock.cyxbs.api.account.IUserStateService
 import com.mredrock.cyxbs.lib.base.spi.InitialManager
 import com.mredrock.cyxbs.lib.base.spi.InitialService
 import com.mredrock.cyxbs.lib.utils.extensions.*
+import com.mredrock.cyxbs.lib.utils.network.mapOrThrowApiException
 import com.mredrock.cyxbs.lib.utils.service.impl
 import com.mredrock.cyxbs.sport.model.network.SportDetailApiService
 import kotlinx.coroutines.flow.*

--- a/module_store/src/main/java/com/mredrock/cyxbs/store/page/center/viewmodel/StoreCenterViewModel.kt
+++ b/module_store/src/main/java/com/mredrock/cyxbs/store/page/center/viewmodel/StoreCenterViewModel.kt
@@ -1,13 +1,12 @@
 package com.mredrock.cyxbs.store.page.center.viewmodel
 
-import android.util.Log
 import androidx.core.content.edit
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.mredrock.cyxbs.lib.base.ui.BaseViewModel
 import com.mredrock.cyxbs.lib.utils.extensions.getSp
-import com.mredrock.cyxbs.lib.utils.extensions.mapOrThrowApiException
 import com.mredrock.cyxbs.lib.utils.network.api
+import com.mredrock.cyxbs.lib.utils.network.mapOrInterceptException
 import com.mredrock.cyxbs.store.bean.StampCenter
 import com.mredrock.cyxbs.store.network.ApiService
 import com.mredrock.cyxbs.store.utils.Date
@@ -52,14 +51,11 @@ class StoreCenterViewModel: BaseViewModel() {
     fun refresh() {
         ApiService::class.api
             .getStampCenter()
-            .mapOrThrowApiException()
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
-            .doOnError {
-                Log.d("ggg", "(StoreCenterViewModel.kt:59) -> doOnError")
+            .mapOrInterceptException {
                 _refreshIsSuccessful.postValue(false)
             }.safeSubscribeBy {
-                Log.d("ggg", "(StoreCenterViewModel.kt:60) -> safeSubscribeBy")
                 _refreshIsSuccessful.postValue(true)
                 _stampCenterData.postValue(it)
             }

--- a/module_store/src/main/java/com/mredrock/cyxbs/store/page/record/viewmodel/RecordViewModel.kt
+++ b/module_store/src/main/java/com/mredrock/cyxbs/store/page/record/viewmodel/RecordViewModel.kt
@@ -3,8 +3,8 @@ package com.mredrock.cyxbs.store.page.record.viewmodel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.mredrock.cyxbs.lib.base.ui.BaseViewModel
-import com.mredrock.cyxbs.lib.utils.extensions.mapOrThrowApiException
 import com.mredrock.cyxbs.lib.utils.network.api
+import com.mredrock.cyxbs.lib.utils.network.mapOrInterceptException
 import com.mredrock.cyxbs.store.bean.ExchangeRecord
 import com.mredrock.cyxbs.store.bean.StampGetRecord
 import com.mredrock.cyxbs.store.network.ApiService
@@ -45,10 +45,9 @@ class RecordViewModel : BaseViewModel() {
     fun getExchangeRecord() {
         ApiService::class.api
             .getExchangeRecord()
-            .mapOrThrowApiException()
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
-            .doOnError {
+            .mapOrInterceptException {
                 _exchangeRecordIsSuccessful.postValue(false)
             }.safeSubscribeBy {
                 _exchangeRecordIsSuccessful.postValue(true)
@@ -60,10 +59,9 @@ class RecordViewModel : BaseViewModel() {
     fun getFirstPageGetRecord() {
         ApiService::class.api
             .getStampGetRecord(1, 30)
-            .mapOrThrowApiException()
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
-            .doOnError {
+            .mapOrInterceptException {
                 _firstPageGetRecordIsSuccessful.postValue(false)
             }.safeSubscribeBy {
                 _firstPageGetRecordIsSuccessful.postValue(true)
@@ -74,10 +72,9 @@ class RecordViewModel : BaseViewModel() {
     fun getNextPageGetRecord() {
         ApiService::class.api
             .getStampGetRecord(nowPage + 1, 30)
-            .mapOrThrowApiException()
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
-            .doOnError {
+            .mapOrInterceptException {
                 _nestPageGetRecordIsSuccessful.postValue(false)
             }.safeSubscribeBy {
                 _nestPageGetRecordIsSuccessful.postValue(true)


### PR DESCRIPTION
## 更优雅的异常处理
网络请求新增 mapOrInterceptException() 方法，使用更优雅的 DSL 写法来处理  
具体写法可参考 lib_utils 模块中的 network/ApiRxjava.kt 注释

## 更优雅的取值
ArgumentHelper 和 IntentHelper 用于方便处理 arguments 和 intent 中的变量  
以后 Fragment 的 argument 可以使用如下写法：
```kotlin
class TestFragment : BaseFragment() {
  companion object {
    fun newInstance(code: Int, info: String): TestFragment {
      return TestFragment().apply { 
        arguments = bundleOf(
          this::mCode.name to code, // 直接使用变量的名字
          this::mInfo.name to info
        )
      }
    }
  }
  
  private val mCode by arguments.helper<Int>() // 原理是直接使用这个变量的名字来拿值
  private var mInfo by arguments.helper<String>() // 支持 var 再修改
}
```
### 缺点
因为这种写法需要那个变量的名字，所以在使用 ARouter 跨模块时有点麻烦（除非使用 api 模块），这个更适合于同一个模块内使用