### PR TITLE
:bug: 修复潘多拉未接入的问题

### DIFF
--- a/build-logic/core/base/src/main/kotlin/BaseApplicationPlugin.kt
+++ b/build-logic/core/base/src/main/kotlin/BaseApplicationPlugin.kt
@@ -1,4 +1,5 @@
 import com.mredrock.cyxbs.convention.config.Config
+import com.mredrock.cyxbs.convention.depend.lib.debugDependLibDebug
 import org.gradle.api.JavaVersion
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.kotlin.dsl.apply
@@ -109,6 +110,8 @@ internal class BaseApplicationPlugin : BasePlugin() {
             }
 
         }
+        //潘多拉
+        debugDependLibDebug()
 
     }
 


### PR DESCRIPTION
问题：
潘多拉接入故障
经排查是base插件忘记debugDependLibDebug
解决：
在base插件通过调用debugDependLibDebug引入debug模块（debug模块有注册init pandora的service）