### PR TITLE
:construction_worker: bug fix

### DIFF
--- a/.github/scripts/push_release.py
+++ b/.github/scripts/push_release.py
@@ -8,10 +8,19 @@ if os.path.exists("./release_json/release.json"):
     # 跟网络上的最新数据比对
     with open("./release_json/release.json") as f:
         info = json.loads(f.read())
-    content_json = info.content_json
+        print("本地数据: ")
+        print(info)
+    content_json = info["content_json"]
     latest = requests.get(f"{base_url}/cyxbsAppUpdate.json").json()
+    print("云端数据: ")
+    print(latest)
     # 不相同说明有更新
     if latest.version_code != content_json.version_code:
         # 检查是否到时间了，到了就直接更新json
-        if time.time() > info.update_time: 
+        if time.time() > info["update_time"]: 
+            print("触发发版操作")
             print(requests.post(f"{base_url}/cyxbsAppUpdate.json", json=content_json, headers={ "token": token }).json())
+        else:
+            print("没到发版时间")
+    else:
+        print("已是最新版本")

--- a/.github/workflows/release_scheule.yml
+++ b/.github/workflows/release_scheule.yml
@@ -1,7 +1,10 @@
 name: Release-Schedule
 on: 
+  workflow_dispatch:
   schedule: 
     # 每小时检查
+    # 实际上github action CI执行定时任务的时间并不精确，所以没办法控制准时发版
+    # 也许可以迁移到云函数，也能避免创建太多Job
     - cron: '0 * * * *'
 jobs:
   schedule:
@@ -10,6 +13,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: develop
+      # 设置时区
+      - uses: szenius/set-timezone@v1.0
+        with:
+          timezoneLinux: "Asia/Singapore"
       - name: Set up Python
         uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
修复定时发版CI

值得注意的是，Github Action的定时任务执行时间并不精确，所以可能无法达到精确控制发版时间的目的

一个可用的备选是云函数（并且也会更好测试）