### PR TITLE
:bug: 修护偶然发现的重连拦截器问题

### DIFF
--- a/lib_utils/src/main/java/com/mredrock/cyxbs/lib/utils/network/ApiGenerator.kt
+++ b/lib_utils/src/main/java/com/mredrock/cyxbs/lib/utils/network/ApiGenerator.kt
@@ -398,7 +398,7 @@ object ApiGenerator {
                 END_POINT_REDROCK_PROD -> {
                     val url = getBackupUrl()
                     mBackupUrl = url
-                    useBackupUrl(url, chain)
+                    response = useBackupUrl(url, chain)
                 }
 
                 else -> throw RuntimeException("未知请求头！")


### PR DESCRIPTION
在没有设置 response 时第一次请求会直接抛出异常，但因为设置了 mBackupUrl，后续请求会请求成功