### PR TITLE
:fire: 移除了build-logic模块下的gradle脚本中对java.toolchain的显式版本要求。现在把项目拉下来后可以直…

### DIFF
--- a/build-logic/manager/build.gradle.kts
+++ b/build-logic/manager/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
   `kotlin-dsl`
 }
 
-java.toolchain.languageVersion.set(JavaLanguageVersion.of(libs.versions.javaTarget.get()))
+//java.toolchain.languageVersion.set(JavaLanguageVersion.of(libs.versions.javaTarget.get()))
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
   kotlinOptions {
     jvmTarget = libs.versions.kotlinJvmTarget.get()

--- a/build-logic/plugin/cache/build.gradle.kts
+++ b/build-logic/plugin/cache/build.gradle.kts
@@ -12,7 +12,7 @@ gradlePlugin {
     }
 }
 
-java.toolchain.languageVersion.set(JavaLanguageVersion.of(libs.versions.javaTarget.get()))
+//java.toolchain.languageVersion.set(JavaLanguageVersion.of(libs.versions.javaTarget.get()))
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
     kotlinOptions {
         jvmTarget = libs.versions.kotlinJvmTarget.get()

--- a/build-logic/plugin/checker/build.gradle.kts
+++ b/build-logic/plugin/checker/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
   `kotlin-dsl`
 }
-java.toolchain.languageVersion.set(JavaLanguageVersion.of(libs.versions.javaTarget.get()))
+//java.toolchain.languageVersion.set(JavaLanguageVersion.of(libs.versions.javaTarget.get()))
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
   kotlinOptions {
     jvmTarget = libs.versions.kotlinJvmTarget.get()


### PR DESCRIPTION
…接使用JDK17跑通项目的构建过程(no locally installed toolchains match 错误应该不会再出现，大概)