### PR TITLE
:sparkles: 支持 arm64-simulator 虚拟机启动 & 移除未在使用的友盟相关依赖

### DIFF
--- a/cyxbs-applications/pro/iosApp/CyxbsMobile2019_iOS.xcodeproj/project.pbxproj
+++ b/cyxbs-applications/pro/iosApp/CyxbsMobile2019_iOS.xcodeproj/project.pbxproj
@@ -7570,7 +7570,6 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -7661,7 +7660,6 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 727CVV9PLJ;
 				EXCLUDED_ARCHS = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 $(inherited)";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/CyxbsMobile2019_iOS/Supporting\\ Files/OneSDK",
@@ -7716,7 +7714,6 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 727CVV9PLJ;
 				EXCLUDED_ARCHS = "";
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 $(inherited)";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/CyxbsMobile2019_iOS/Supporting\\ Files/OneSDK",

--- a/cyxbs-applications/pro/iosApp/CyxbsMobile2019_iOS/Supporting Files/HTTPDNS/NetworkManager.m
+++ b/cyxbs-applications/pro/iosApp/CyxbsMobile2019_iOS/Supporting Files/HTTPDNS/NetworkManager.m
@@ -9,7 +9,6 @@
 #import "NetworkManager.h"
 #import <sys/socket.h>
 #import <netinet/in.h>
-#import <netinet6/in6.h>
 #import <arpa/inet.h>
 #import <ifaddrs.h>
 #import <netdb.h>

--- a/cyxbs-applications/pro/iosApp/CyxbsMobile2019_iOS/Swift/Login/User/Item/UserItemTool.m
+++ b/cyxbs-applications/pro/iosApp/CyxbsMobile2019_iOS/Swift/Login/User/Item/UserItemTool.m
@@ -7,7 +7,6 @@
 //
 
 #import "UserItemTool.h"
-#import <UMShare/UMShare.h>
 #import "UserDefaultTool.h"
 #import "掌上重邮-Swift.h"        // 将Swift中的类暴露给OC
 @interface UserItemTool ()

--- a/cyxbs-applications/pro/iosApp/Podfile
+++ b/cyxbs-applications/pro/iosApp/Podfile
@@ -4,8 +4,10 @@ source 'https://github.com/aliyun/aliyun-specs.git'
 platform :ios, '26.0'
 use_frameworks!
 
-# 是否为模拟器环境，真机/发版请改为 false
-IS_SIMULATOR = false
+# 是否为模拟器环境，优先读取环境变量，未设置时默认 true（模拟器）：
+#   pod install                  → 模拟器（默认）
+#   IS_SIMULATOR=0 pod install   → 真机 / 发布包
+IS_SIMULATOR = ENV.fetch('IS_SIMULATOR', '1') != '0'
 
 inhibit_all_warnings!
 
@@ -27,17 +29,10 @@ target 'CyxbsMobile2019_iOS' do
   pod 'Masonry'  # 自动布局库
   pod 'MJRefresh'  # 下拉刷新库
   pod 'AMapLocation-NO-IDFA'  # 高德地图定位库
-  pod 'AMap3DMap-NO-IDFA', '~> 10.1.500'  # 高德地图3D库
+  pod 'AMap3DMap-NO-IDFA'  # 高德地图3D库
   pod 'MJExtension'  # 字典和模型之间的转换库
   pod 'SDCycleScrollView'  # 轮播图库
   pod 'FSCalendar'  # iOS日历库，兼容Objective-C和Swift
-  
-  pod 'UMCommon'  # 友盟统计库
-  pod 'UMDevice'  # 友盟设备信息库
-  pod 'UMVerify'  # 友盟一键登录库
-  pod 'UMCCommonLog',           :configurations => ['Debug']  # 友盟日志库
-  pod 'UMShare/Social/WeChat'  # 友盟微信分享库
-  pod 'UMShare/Social/QQ'  # 友盟QQ分享库
   
   pod 'IQKeyboardManager'  # 键盘管理库
   pod 'Bugly'  # 腾讯Bugly崩溃日志上报库
@@ -83,21 +78,118 @@ post_install do |installer|
       config.build_settings['CODE_SIGNING_REQUIRED'] = "NO"  # 不要求代码签名
       config.build_settings['CODE_SIGNING_ALLOWED'] = "NO"  # 不允许代码签名
       
-      #如果是模拟器运行
-      if IS_SIMULATOR
-        if M1_VALID_ARCHS.include?(target.name)
-          config.build_settings['VALID_ARCHS'] = 'x86_64'  # 在模拟器上仅使用 x86_64 架构
-        end
-        
-        if M1_EXCLUDED_ARCHS_iphonesimulator.include?(target.name)
-          config.build_settings['EXCLUDED_ARCHS[sdk=iphonesimulator*]'] = 'arm64'  # 在模拟器上排除 arm64 架构
-        end
+      # Xcode 26 / clang 21 把链式比较(a<b<c)等老写法默认升级成 error，
+      # inhibit_all_warnings! 的 -w 压不住"默认 error"级诊断；老 pod(如 YYKit)需显式关闭。
+      config.build_settings['OTHER_CFLAGS'] = "#{config.build_settings['OTHER_CFLAGS'] || '$(inherited)'} -Wno-parentheses"
 
-      else
-        # 在模拟器上排除 arm64 架构
-        config.build_settings['EXCLUDED_ARCHS[sdk=iphonesimulator*]'] = 'arm64'  
+      # Apple Silicon 模拟器只有 arm64，而 CocoaPods 为 AMap 等不含 arm64-sim slice 的 pod
+      # 在聚合 target(Pods-CyxbsMobile2019_iOS)的 xcconfig 里自动写入
+      # EXCLUDED_ARCHS[sdk=iphonesimulator*] = arm64，导致该 target 啥都不产出，链接失败。
+      # 这里强制清除，让聚合 target 能在 arm64 模拟器上正常构建。
+      if target.name == 'Pods-CyxbsMobile2019_iOS'
+        config.build_settings['EXCLUDED_ARCHS[sdk=iphonesimulator*]'] = ''
       end
     end
+  end
+  
+  # AMap / Bugly 官方预编译 fat framework 只有 arm64-device + x86_64-simulator，
+  # 没有 arm64-simulator slice，在 Apple Silicon 模拟器上链接报 "built for iOS" 错误。
+  #
+  # 方案：解包 arm64-device 静态库 → vtool 改平台标记 → 重打包为 arm64-sim → 替换。
+  # lipo 不允许同一 fat binary 里出现两个 arm64（无论平台标记），因此模拟器包和真机包互斥。
+  # 通过顶部的 IS_SIMULATOR 变量控制：true = patch 为模拟器，false = 还原为真机/发布包。
+  require 'tmpdir'
+  restore_mode = !IS_SIMULATOR
+  [
+    ['AMapFoundation-NO-IDFA', 'AMapFoundationKit'],
+    ['AMap3DMap-NO-IDFA',      'MAMapKit'],
+    ['AMapLocation-NO-IDFA',   'AMapLocationKit'],
+    ['Bugly',                  'Bugly'],
+  ].each do |pod_dir, fw_name|
+    fw_bin = File.join(installer.sandbox.root, pod_dir, "#{fw_name}.framework", fw_name)
+    next unless File.exist?(fw_bin)
+
+    orig = "#{fw_bin}.device-orig"
+
+    if restore_mode
+      if File.exist?(orig)
+        FileUtils.cp(orig, fw_bin)
+        puts "Restored #{fw_name} to device binary"
+      end
+      next
+    end
+
+    # 首次 patch 时保存原始 device 二进制备份（确保幂等：每次都从原始备份开始 patch）
+    FileUtils.cp(fw_bin, orig) unless File.exist?(orig)
+    fw_source = orig   # 始终从 device-orig 提取，避免重复 pod install 后 patch 已 patch 过的文件
+
+    tmp      = Dir.mktmpdir("patch_#{fw_name}")
+    dev_a    = "#{tmp}/arm64-dev.a"
+    objs_dir = "#{tmp}/objs"
+    sim_a    = "#{tmp}/arm64-sim.a"
+    x86_a    = "#{tmp}/x86_64.a"
+
+    # 提取 arm64-device 静态库
+    next unless system("lipo '#{fw_source}' -thin arm64 -output '#{dev_a}' 2>/dev/null")
+
+    # 解包所有 .o，用 vtool 把平台从 ios(2) 改为 ios-simulator(7)，再重打包
+    Dir.mkdir(objs_dir)
+    Dir.chdir(objs_dir) do
+      system("ar x '#{dev_a}' 2>/dev/null")
+      objs = Dir.glob('*.o')
+      objs.each do |o|
+        # vtool 对含 LC_BUILD_VERSION 的 .o 有效；
+        # 对旧格式 LC_VERSION_MIN_IPHONEOS 因 load commands 空间不足会失败，
+        # 此时改为用 xcrun 重新编译一个等效的 arm64-simulator dummy 替换。
+        unless system("vtool -set-build-version 7 15.0 15.0 -replace -output '#{o}' '#{o}' 2>/dev/null")
+          warn "  [#{fw_name}] vtool fallback (old LC_VERSION_MIN): #{o} → replaced with empty stub"
+          func = File.basename(o, '.o').gsub(/[^a-zA-Z0-9]/, '_')
+          dm = "#{tmp}/#{func}.m"
+          File.write(dm, "void __attribute__((used)) #{func}(void) {}\n")
+          system("xcrun clang -arch arm64 -target arm64-apple-ios15.0-simulator -c '#{dm}' -o '#{o}' 2>/dev/null")
+        end
+      end
+      system("ar -r '#{sim_a}' #{objs.map { |o| "'#{o}'" }.join(' ')} 2>/dev/null")
+      system("ranlib '#{sim_a}' 2>/dev/null")
+    end
+    next unless File.exist?(sim_a)
+
+    # 用 arm64-sim 替换（保留 x86_64-sim 如果存在）
+    # 注意：lipo 不允许同一 fat 里有两个 arm64，无法同时保留 device + sim slice
+    has_x86 = system("lipo '#{fw_source}' -thin x86_64 -output '#{x86_a}' 2>/dev/null") && File.exist?(x86_a)
+    if has_x86
+      system("lipo -create '#{sim_a}' '#{x86_a}' -output '#{fw_bin}'")
+    else
+      FileUtils.cp(sim_a, fw_bin)
+    end
+    FileUtils.rm_rf(tmp)
+    puts "Patched #{fw_name} for arm64 simulator"
+  end
+
+  # 本项目未使用 webp 解码；YYKit 自带的 WebP.framework 缺 arm64 模拟器 slice，
+  # 在 Xcode 26 的 arm64 模拟器上链接失败(Building for 'iOS-simulator', but linking ... built for 'iOS')。
+  # 删除它并去掉 -framework WebP，让 YYImageCoder 的 __has_include(<webp/...>) 失效
+  # (YYIMAGE_WEBP_ENABLED=0)，webp 代码不编译、不再链接该缺 slice 的二进制。
+  require 'fileutils'
+  webp_fw = File.join(installer.sandbox.root, 'YYKit', 'Vendor', 'WebP.framework')
+  FileUtils.rm_rf(webp_fw)
+  Dir.glob(File.join(installer.sandbox.root, 'Target Support Files', 'YYKit', 'YYKit.*.xcconfig')).each do |f|
+    text = File.read(f)
+    patched = text.gsub(' -framework "WebP"', '')
+    File.write(f, patched) if patched != text
+  end
+
+  # Xcode 26 / iOS 26 SDK 把 netinet6/in6.h 设为私有头，禁止直接 import（头内含 #error 提示改用 netinet/in.h）。
+  # 已废弃的 AFNetworking 直接 import 了它 → "Use of private header from outside its module"。
+  # 删除这两处多余 import（上一行的 <netinet/in.h> 已涵盖 IPv6 定义）。
+  ['AFHTTPSessionManager.m', 'AFNetworkReachabilityManager.m'].each do |name|
+    af = File.join(installer.sandbox.root, 'AFNetworking', 'AFNetworking', name)
+    next unless File.exist?(af)
+    text = File.read(af)
+    patched = text.gsub(/^[ \t]*#import <netinet6\/in6\.h>[ \t]*\r?\n/, '')
+    next if patched == text
+    File.chmod(0644, af)   # CocoaPods 下载的源码是只读(444)，先加写权限再改
+    File.write(af, patched)
   end
 end
 

--- a/cyxbs-applications/pro/iosApp/Podfile.lock
+++ b/cyxbs-applications/pro/iosApp/Podfile.lock
@@ -17,14 +17,14 @@ PODS:
   - Alamofire (5.10.2)
   - AlicloudHTTPDNS (2.2.0):
     - AlicloudUtils
-  - AlicloudUTDID (1.6.1)
+  - AlicloudUTDID (1.6.1.1)
   - AlicloudUtils (2.0.1):
     - AlicloudUTDID
-  - AMap3DMap-NO-IDFA (10.1.600):
-    - AMapFoundation-NO-IDFA (>= 1.8.0)
-  - AMapFoundation-NO-IDFA (1.8.2)
-  - AMapLocation-NO-IDFA (2.10.0):
-    - AMapFoundation-NO-IDFA (>= 1.8.0)
+  - AMap3DMap-NO-IDFA (11.1.200):
+    - AMapFoundation-NO-IDFA (>= 1.8.7)
+  - AMapFoundation-NO-IDFA (1.8.7)
+  - AMapLocation-NO-IDFA (2.11.1):
+    - AMapFoundation-NO-IDFA (>= 1.8.7)
   - Bugly (2.6.1)
   - FluentDarkModeKit (1.0.4)
   - FMDB (2.7.12):
@@ -102,28 +102,6 @@ PODS:
     - TZImagePickerController/Location (= 3.8.9)
   - TZImagePickerController/Basic (3.8.9)
   - TZImagePickerController/Location (3.8.9)
-  - UMCCommonLog (2.0.2)
-  - UMCommon (7.5.3):
-    - UMDevice
-  - UMDevice (3.4.0)
-  - UMShare/Core (6.10.15):
-    - UMCommon
-  - UMShare/Social/QQ (6.10.15):
-    - UMCommon
-    - UMShare/Core
-    - UMShare/Social/ReducedQQ
-  - UMShare/Social/ReducedQQ (6.10.15):
-    - UMCommon
-    - UMShare/Core
-  - UMShare/Social/ReducedWeChat (6.10.15):
-    - UMCommon
-    - UMShare/Core
-  - UMShare/Social/WeChat (6.10.15):
-    - UMCommon
-    - UMShare/Core
-    - UMShare/Social/ReducedWeChat
-  - UMVerify (3.1.0):
-    - UMCommon
   - XBSBugly (0.1.0):
     - Bugly
   - YBImageBrowser (3.0.9):
@@ -142,7 +120,7 @@ DEPENDENCIES:
   - AFNetworking
   - Alamofire
   - AlicloudHTTPDNS (= 2.2.0)
-  - AMap3DMap-NO-IDFA (~> 10.1.500)
+  - AMap3DMap-NO-IDFA
   - AMapLocation-NO-IDFA
   - Bugly
   - FluentDarkModeKit
@@ -169,12 +147,6 @@ DEPENDENCIES:
   - SwiftyJSON
   - TOCropViewController
   - TZImagePickerController
-  - UMCCommonLog
-  - UMCommon
-  - UMDevice
-  - UMShare/Social/QQ
-  - UMShare/Social/WeChat
-  - UMVerify
   - XBSBugly (from `Development Pods/`)
   - YBImageBrowser
   - YYImage
@@ -219,11 +191,6 @@ SPEC REPOS:
     - SwiftyJSON
     - TOCropViewController
     - TZImagePickerController
-    - UMCCommonLog
-    - UMCommon
-    - UMDevice
-    - UMShare
-    - UMVerify
     - YBImageBrowser
     - YYImage
     - YYKit
@@ -236,11 +203,11 @@ SPEC CHECKSUMS:
   AFNetworking: 3bd23d814e976cd148d7d44c3ab78017b744cd58
   Alamofire: 7193b3b92c74a07f85569e1a6c4f4237291e7496
   AlicloudHTTPDNS: b1efa2e175672c5822d322c68efeae62068d7d05
-  AlicloudUTDID: 5d2f22d50e11eecd38f30bc7a48c71925ea90976
+  AlicloudUTDID: f0cde02afb754d7d3591d2a21bfe0cae8c89bce5
   AlicloudUtils: ef4436f52b828b1182b002373758ecb88068e679
-  AMap3DMap-NO-IDFA: 5279e94b7d4d6561826c63411f52389a3b2e2eff
-  AMapFoundation-NO-IDFA: 6ce0ef596d4eb8d934ff498e56747b6de1247b05
-  AMapLocation-NO-IDFA: 735791aeb1ba52dff666e4158b86caf4b68b5be7
+  AMap3DMap-NO-IDFA: 393a24abb0451fed2daa4316c8d3d356a395f2be
+  AMapFoundation-NO-IDFA: f48acbf6e74913dc6744581053f7d984f2432850
+  AMapLocation-NO-IDFA: 0fa6e7d5e42e10253f4437424d98966f53760862
   Bugly: 217ac2ce5f0f2626d43dbaa4f70764c953a26a31
   FluentDarkModeKit: b6317653a00329564582884772ec57c4eaad1a1f
   FMDB: 728731dd336af3936ce00f91d9d8495f5718a0e6
@@ -269,16 +236,11 @@ SPEC CHECKSUMS:
   SwiftyJSON: f5b1bf1cd8dd53cd25887ac0eabcfd92301c6a5a
   TOCropViewController: 80b8985ad794298fb69d3341de183f33d1853654
   TZImagePickerController: 456f470b5dea97b37226ec7a694994a8663340b2
-  UMCCommonLog: bea707e50c85cef4b0eb47cc5c7226bb843245ca
-  UMCommon: 3b850836e8bc162b4e7f6b527d30071ed8ea75a1
-  UMDevice: dcdf7ec167387837559d149fbc7d793d984faf82
-  UMShare: e8448c955153770c40a87fa26267bddf8c5b0691
-  UMVerify: 832cbda6a895a798fd5619035594c9370561158d
-  XBSBugly: 15cb1f1d1f30e3c1e0c902eafe566bada6fcf02e
+  XBSBugly: 96823fe01bb05751bdd387dd0b870e7c0e882198
   YBImageBrowser: 7ecc8bf33ffa5f3b94c397c29b4f3638dd37f527
   YYImage: 1e1b62a9997399593e4b9c4ecfbbabbf1d3f3b54
   YYKit: 7cda43304a8dc3696c449041e2cb3107b4e236e7
 
-PODFILE CHECKSUM: 5666fb8a91394f227184da1e450ca2fe1235deff
+PODFILE CHECKSUM: e76efff3db80da5d2a0acbd130df4a8f87fb8e18
 
 COCOAPODS: 1.16.2

--- a/cyxbs-applications/pro/iosApp/README.md
+++ b/cyxbs-applications/pro/iosApp/README.md
@@ -18,6 +18,42 @@
 
 
 
+## 环境配置 & pod install 说明
+
+### 模拟器开发（默认）
+
+```bash
+# 以 iosApp 作为 iOS 项目的根目录 
+cd cyxbs-applications/pro/iosApp
+
+# 安装依赖 (⚠️注意：如果真机调试/打发布包时使用 IS_SIMULATOR=0 pod install)
+pod install
+
+# 进入 xcworkspace 而不是进入 xcworkspace
+open CyxbsMobile2019_iOS.xcworkspace
+```
+
+> 默认即为模拟器模式。AMap（高德地图）和 Bugly 等预编译 fat framework  
+> 不含 arm64-simulator slice，脚本会自动 patch 为 arm64-sim 以支持 Apple Silicon 模拟器。
+
+### 真机调试 / 打发布包
+
+```bash
+# 需要附带上 IS_SIMULATOR=0
+IS_SIMULATOR=0 pod install
+```
+
+> 从 `.device-orig` 备份还原原始 arm64-device 二进制，之后可正常 Archive 或真机运行。  
+> 打完包若需切回模拟器，再执行一次默认的 `pod install` 即可。
+
+### 注意事项
+
+- Podfile 无需手动修改，通过环境变量 `IS_SIMULATOR=0/1` 控制即可
+- `Pods/` 目录不入 git，每次 clone 后需要执行 `pod install`
+- 若更新了 AMap / Bugly pod 版本（`pod update`），脚本会自动重建备份，无需额外操作
+
+
+
 
 
 <img src="https://is1-ssl.mzstatic.com/image/thumb/Purple116/v4/1a/05/33/1a05333c-5e87-6158-9da5-8ad42ae43565/AppIcon-0-0-1x_U007emarketing-0-0-0-7-0-0-sRGB-0-0-0-GLES2_U002c0-512MB-85-220-0-0.png/246x0w.webp" width = "300">


### PR DESCRIPTION
背景：新版本 XCode 只支持 arm64-simulator 架构的模拟器，但因三方库依赖问题架构不兼容导致模拟器不可用

本 mr 解决了在新版本 XCode 中的以下问题
- AMap / Bugly 官方预编译只有 arm64-device + x86_64-simulator，通过 patch 将 arm64-device 修改为 arm64-simulator 架构以支持模拟器启动
- YYKit 自带的 WebP.framework 缺 arm64 模拟器，因为本项目未使用 webp 解码，所以直接去掉了 YYKit 内部的 WebP
- netinet6/in6.h 在新版本被设置为了私有头，通过修改 AFNetworking 依赖文件解决

注意事项：
-  真机调试 / 打发布包需要使用 `IS_SIMULATOR=0 pod install` 来安装依赖（因为 patch arm64-simulator 后不可共存）